### PR TITLE
Fix returned index of waves and pressure points

### DIFF
--- a/src/Noise/Real/Real.cpp
+++ b/src/Noise/Real/Real.cpp
@@ -86,13 +86,13 @@ void Real::remove()
 int Real::addWave(Ogre::Vector2 dir, float A, float T, float p)
 {
     mWaves.push_back(Wave(dir,A,T,p));
-    return mWaves.size();
+    return (mWaves.size() - 1);
 }
 
 int Real::addPressurePoint(Ogre::Vector2 Orig, float p, float T, float L)
 {
     mPressurePoints.push_back(PressurePoint(Orig,p,T,L));
-    return mPressurePoints.size();
+    return (mPressurePoints.size() - 1);
 }
 
 Wave Real::getWave(int id) const


### PR DESCRIPTION
Fixing returned index of waves and pressure points, vector is 0 based.

It was returning the vector size().
